### PR TITLE
Add module.exports to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "nyc --reporter=html --reporter=lcov --reporter=text npm run test:nocover",
     "test:nocover": "mocha --full-trace -R nyan --compilers js:babel-core/register test/typiql.test.js",
-    "build": "npm run build && npm run build:flow",
+    "build": "npm run build:lib && npm run build:flow",
     "build:lib": "babel src/typiql.js --out-file build/typiql.js",
     "build:flow": "flow-copy-source -v -i 'test/**' src build",
     "prepublish": "npm build",
@@ -26,7 +26,8 @@
       "es2015"
     ],
     "plugins": [
-      "transform-flow-strip-types"
+      "transform-flow-strip-types",
+      "add-module-exports"
     ]
   },
   "author": "TouchBistro",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-transform-flow-strip-types": "^6.21.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,10 @@ babel-messages@^6.8.0:
   dependencies:
     babel-runtime "^6.0.0"
 
+babel-plugin-add-module-exports@0.2.1:
+  version "0.2.1"
+  resolved "http://storage.mds.yandex.net/get-npm/69187/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
+
 babel-plugin-check-es2015-constants@^6.3.13:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz#dbf024c32ed37bfda8dee1e76da02386a8d26fe7"


### PR DESCRIPTION
Added `babel-plugin-add-module-exports` which adds `module.exports = exports['default'];` to build
This allows us to use this module without imports, like:
```js
const tql = require('typiql');
```
instead of:
```js
const tql = require('typiql').default;
```